### PR TITLE
feat(multisig): implement advanced multisig workflows and security co…

### DIFF
--- a/contracts/multisig/AdvancedMultiSig.ts
+++ b/contracts/multisig/AdvancedMultiSig.ts
@@ -1,0 +1,963 @@
+import { IAdvancedMultiSig } from './interfaces/IAdvancedMultiSig';
+import { MultiSigLib } from './libraries/MultiSigLib';
+import {
+    AdvancedMultiSigConfig,
+    AdvancedTransaction,
+    BatchPlan,
+    EmergencyActionType,
+    EmergencyOverrideRequest,
+    HierarchicalThresholdRule,
+    TransactionStatus,
+    WorkflowDefinition,
+    WorkflowMode,
+    WorkflowStage
+} from './structures/WorkflowStructure';
+import {
+    MultiSigAnalytics,
+    SignatureRecord,
+    SignerAnalytics,
+    SignatureStatus
+} from './structures/SignatureStructure';
+
+interface InternalSignerStats {
+    signedCount: number;
+    revokedCount: number;
+    totalDelayMs: number;
+    lastSignedAt: number;
+    lastRevokedAt?: number;
+}
+
+export class AdvancedMultiSig implements IAdvancedMultiSig {
+    private owners: Set<string>;
+    private transactions: Map<string, AdvancedTransaction> = new Map();
+    private batches: Map<string, BatchPlan> = new Map();
+    private workflows: Map<string, WorkflowDefinition> = new Map();
+    private integrations: Map<string, (tx: AdvancedTransaction) => void> = new Map();
+    private emergencyRequests: Map<string, EmergencyOverrideRequest> = new Map();
+    private signatureLedger: Map<string, SignatureRecord[]> = new Map();
+    private signerStats: Map<string, InternalSignerStats> = new Map();
+
+    private hierarchicalRules: HierarchicalThresholdRule[] = [];
+
+    private transactionNonce = 0;
+    private batchNonce = 0;
+    private emergencyNonce = 0;
+
+    private totalSignatures = 0;
+    private totalRevocations = 0;
+    private totalConfirmationDelayMs = 0;
+    private totalBatchGasSavings = 0;
+
+    private config: AdvancedMultiSigConfig;
+
+    constructor(
+        initialOwners: string[],
+        initialRules?: HierarchicalThresholdRule[],
+        config?: Partial<AdvancedMultiSigConfig>
+    ) {
+        const sanitizedOwners = Array.from(new Set(initialOwners));
+        if (sanitizedOwners.length < 2) {
+            throw new Error('AdvancedMultiSig: at least two owners required');
+        }
+
+        this.owners = new Set(sanitizedOwners);
+        this.config = {
+            transactionExpiryMs: 7 * 24 * 60 * 60 * 1000,
+            signatureTimelockMs: 5 * 60 * 1000,
+            emergencySuperMajorityPct: 75,
+            defaultWorkflowMode: WorkflowMode.PARALLEL,
+            ...config
+        };
+
+        this.owners.forEach((owner) => {
+            this.signerStats.set(owner, {
+                signedCount: 0,
+                revokedCount: 0,
+                totalDelayMs: 0,
+                lastSignedAt: 0
+            });
+        });
+
+        const rules = initialRules && initialRules.length > 0
+            ? initialRules
+            : this.buildDefaultRules();
+        this.setInternalHierarchicalRules(rules);
+    }
+
+    public submitTransaction(
+        to: string,
+        value: number,
+        data: string,
+        sender: string,
+        workflowId?: string
+    ): string {
+        return this.createTransaction(to, value, data, sender, workflowId);
+    }
+
+    public submitBatch(
+        transactions: Array<{ to: string; value: number; data: string }>,
+        sender: string,
+        workflowId?: string
+    ): string {
+        this.onlyOwner(sender);
+        if (transactions.length === 0) {
+            throw new Error('AdvancedMultiSig: empty batch not allowed');
+        }
+
+        const batchId = `MS_BATCH_${Date.now()}_${this.batchNonce++}`;
+        const transactionIds = transactions.map((tx) =>
+            this.createTransaction(tx.to, tx.value, tx.data, sender, workflowId, batchId)
+        );
+
+        const estimatedGasPerTx = transactionIds.map((transactionId) => {
+            const tx = this.requireTransaction(transactionId);
+            return MultiSigLib.estimateTransactionGas(tx.data, tx.stages.length, tx.requiredSignatures);
+        });
+        const optimization = MultiSigLib.optimizeBatchGas(estimatedGasPerTx);
+
+        const batch: BatchPlan = {
+            id: batchId,
+            submittedBy: sender,
+            transactionIds,
+            createdAt: Date.now(),
+            estimatedStandaloneGas: optimization.originalGas,
+            estimatedBatchGas: optimization.optimizedGas,
+            gasSavings: optimization.gasSavings,
+            gasSavingsPct: optimization.gasSavingsPct,
+            executed: false
+        };
+
+        this.totalBatchGasSavings += optimization.gasSavings;
+        this.batches.set(batchId, batch);
+
+        return batchId;
+    }
+
+    public confirmTransaction(transactionId: string, sender: string, stageId?: string): void {
+        this.onlyOwner(sender);
+
+        const tx = this.requireActiveTransaction(transactionId);
+        if (!tx.eligibleSigners.includes(sender)) {
+            throw new Error('AdvancedMultiSig: signer not eligible for this tier');
+        }
+
+        const stage = this.resolveApprovalStage(tx, sender, stageId);
+        const now = Date.now();
+        const stageReadyAt = tx.stageReadyAt[stage.id] || 0;
+        if (stageReadyAt === 0) {
+            throw new Error('AdvancedMultiSig: stage is not yet active');
+        }
+        if (now < stageReadyAt + stage.timelockMs) {
+            throw new Error('AdvancedMultiSig: stage timelock active');
+        }
+
+        const approvals = tx.stageApprovals[stage.id] || [];
+        if (approvals.includes(sender)) {
+            throw new Error('AdvancedMultiSig: signer already confirmed this stage');
+        }
+
+        approvals.push(sender);
+        tx.stageApprovals[stage.id] = approvals;
+        if (approvals.length >= stage.minApprovals && tx.stageCompletedAt[stage.id] === 0) {
+            tx.stageCompletedAt[stage.id] = now;
+            if (tx.workflowMode === WorkflowMode.SEQUENTIAL) {
+                const stageIndex = tx.stages.findIndex((candidate) => candidate.id === stage.id);
+                const nextStage = tx.stages[stageIndex + 1];
+                if (nextStage && tx.stageReadyAt[nextStage.id] === 0) {
+                    tx.stageReadyAt[nextStage.id] = now;
+                }
+            }
+        }
+
+        this.recordSignature(tx, sender, stage.id, now);
+        this.updateDerivedTransactionState(tx, now);
+
+        this.transactions.set(tx.id, tx);
+    }
+
+    public revokeSignature(transactionId: string, sender: string, stageId?: string): void {
+        this.onlyOwner(sender);
+
+        const tx = this.requireActiveTransaction(transactionId);
+        const stage = this.resolveRevocationStage(tx, sender, stageId);
+        const stageIndex = tx.stages.findIndex((candidate) => candidate.id === stage.id);
+
+        tx.stageApprovals[stage.id] = tx.stageApprovals[stage.id].filter((approver) => approver !== sender);
+        if (tx.stageApprovals[stage.id].length < stage.minApprovals) {
+            tx.stageCompletedAt[stage.id] = 0;
+            if (tx.workflowMode === WorkflowMode.SEQUENTIAL) {
+                this.resetDownstreamStages(tx, stageIndex + 1);
+            }
+        }
+
+        this.recordRevocation(tx, sender, stage.id, Date.now());
+        this.updateDerivedTransactionState(tx, Date.now());
+
+        this.transactions.set(tx.id, tx);
+    }
+
+    public executeTransaction(transactionId: string, sender: string): void {
+        this.onlyOwner(sender);
+
+        const tx = this.requireActiveTransaction(transactionId);
+        const now = Date.now();
+
+        if (now < tx.executeAfter) {
+            throw new Error('AdvancedMultiSig: execution timelock active');
+        }
+
+        this.updateDerivedTransactionState(tx, now);
+        if (tx.status !== TransactionStatus.READY) {
+            throw new Error('AdvancedMultiSig: transaction not ready for execution');
+        }
+
+        const integrationHandler = this.integrations.get(tx.to);
+        if (integrationHandler) {
+            integrationHandler(this.cloneTransaction(tx));
+        }
+
+        tx.status = TransactionStatus.EXECUTED;
+        tx.executedAt = now;
+        tx.lastUpdatedAt = now;
+
+        this.transactions.set(tx.id, tx);
+    }
+
+    public executeBatch(batchId: string, sender: string): string[] {
+        this.onlyOwner(sender);
+
+        const batch = this.batches.get(batchId);
+        if (!batch) {
+            throw new Error('AdvancedMultiSig: batch not found');
+        }
+        if (batch.executed) {
+            throw new Error('AdvancedMultiSig: batch already executed');
+        }
+
+        const now = Date.now();
+        const nonExecutable: string[] = [];
+
+        batch.transactionIds.forEach((transactionId) => {
+            const tx = this.requireActiveTransaction(transactionId);
+            this.updateDerivedTransactionState(tx, now);
+            if (tx.status !== TransactionStatus.READY || now < tx.executeAfter) {
+                nonExecutable.push(transactionId);
+            }
+        });
+
+        if (nonExecutable.length > 0) {
+            throw new Error(
+                `AdvancedMultiSig: batch contains non-executable transactions: ${nonExecutable.join(',')}`
+            );
+        }
+
+        batch.transactionIds.forEach((transactionId) => this.executeTransaction(transactionId, sender));
+        batch.executed = true;
+        this.batches.set(batchId, batch);
+
+        return [...batch.transactionIds];
+    }
+
+    public registerWorkflow(workflow: WorkflowDefinition, sender: string): void {
+        this.onlyOwner(sender);
+        this.validateWorkflowDefinition(workflow);
+        this.workflows.set(workflow.id, this.cloneWorkflowDefinition(workflow));
+    }
+
+    public setHierarchicalRules(rules: HierarchicalThresholdRule[], sender: string): void {
+        this.onlyOwner(sender);
+        this.setInternalHierarchicalRules(rules);
+    }
+
+    public registerIntegration(contractId: string, handler: (tx: AdvancedTransaction) => void, sender: string): void {
+        this.onlyOwner(sender);
+        if (!contractId) {
+            throw new Error('AdvancedMultiSig: integration id is required');
+        }
+        this.integrations.set(contractId, handler);
+    }
+
+    public getRegisteredIntegrations(): string[] {
+        return Array.from(this.integrations.keys());
+    }
+
+    public requestEmergencyOverride(
+        transactionId: string,
+        action: EmergencyActionType,
+        reason: string,
+        sender: string
+    ): string {
+        this.onlyOwner(sender);
+        const tx = this.requireTransaction(transactionId);
+
+        if (tx.status === TransactionStatus.EXECUTED) {
+            throw new Error('AdvancedMultiSig: cannot override executed transaction');
+        }
+
+        const requestId = `EM_OVERRIDE_${Date.now()}_${this.emergencyNonce++}`;
+        const request: EmergencyOverrideRequest = {
+            id: requestId,
+            transactionId,
+            action,
+            reason,
+            requestedBy: sender,
+            createdAt: Date.now(),
+            approvals: [sender],
+            executed: false
+        };
+
+        this.emergencyRequests.set(requestId, request);
+        return requestId;
+    }
+
+    public approveEmergencyOverride(requestId: string, sender: string): void {
+        this.onlyOwner(sender);
+
+        const request = this.emergencyRequests.get(requestId);
+        if (!request) {
+            throw new Error('AdvancedMultiSig: emergency request not found');
+        }
+        if (request.executed) {
+            throw new Error('AdvancedMultiSig: emergency request already executed');
+        }
+        if (request.approvals.includes(sender)) {
+            throw new Error('AdvancedMultiSig: emergency approval already recorded');
+        }
+
+        request.approvals.push(sender);
+        this.emergencyRequests.set(requestId, request);
+    }
+
+    public executeEmergencyOverride(requestId: string, sender: string): void {
+        this.onlyOwner(sender);
+
+        const request = this.emergencyRequests.get(requestId);
+        if (!request) {
+            throw new Error('AdvancedMultiSig: emergency request not found');
+        }
+        if (request.executed) {
+            throw new Error('AdvancedMultiSig: emergency request already executed');
+        }
+
+        const requiredApprovals = MultiSigLib.calculateSuperMajority(
+            this.owners.size,
+            this.config.emergencySuperMajorityPct
+        );
+        if (request.approvals.length < requiredApprovals) {
+            throw new Error('AdvancedMultiSig: emergency override requires super-majority approvals');
+        }
+
+        const tx = this.requireTransaction(request.transactionId);
+        const now = Date.now();
+
+        if (request.action === EmergencyActionType.EXECUTE_TRANSACTION) {
+            if (tx.status === TransactionStatus.EXECUTED) {
+                throw new Error('AdvancedMultiSig: transaction already executed');
+            }
+
+            const integrationHandler = this.integrations.get(tx.to);
+            if (integrationHandler) {
+                integrationHandler(this.cloneTransaction(tx));
+            }
+
+            tx.status = TransactionStatus.EXECUTED;
+            tx.executedAt = now;
+            tx.lastUpdatedAt = now;
+        } else {
+            if (tx.status === TransactionStatus.EXECUTED) {
+                throw new Error('AdvancedMultiSig: cannot cancel executed transaction');
+            }
+            tx.status = TransactionStatus.CANCELLED;
+            tx.cancelledReason = request.reason;
+            tx.lastUpdatedAt = now;
+        }
+
+        request.executed = true;
+        this.transactions.set(tx.id, tx);
+        this.emergencyRequests.set(requestId, request);
+    }
+
+    public getEmergencyOverrideRequest(requestId: string): EmergencyOverrideRequest {
+        const request = this.emergencyRequests.get(requestId);
+        if (!request) {
+            throw new Error('AdvancedMultiSig: emergency request not found');
+        }
+        return {
+            ...request,
+            approvals: [...request.approvals]
+        };
+    }
+
+    public getTransaction(transactionId: string): AdvancedTransaction {
+        const tx = this.requireTransaction(transactionId);
+        return this.cloneTransaction(tx);
+    }
+
+    public getBatchPlan(batchId: string): BatchPlan {
+        const batch = this.batches.get(batchId);
+        if (!batch) {
+            throw new Error('AdvancedMultiSig: batch not found');
+        }
+        return {
+            ...batch,
+            transactionIds: [...batch.transactionIds]
+        };
+    }
+
+    public getOwners(): string[] {
+        return Array.from(this.owners);
+    }
+
+    public getSystemAnalytics(): MultiSigAnalytics {
+        let readyTransactions = 0;
+        let executedTransactions = 0;
+        let cancelledTransactions = 0;
+        let expiredTransactions = 0;
+
+        this.transactions.forEach((tx) => {
+            if (tx.status === TransactionStatus.READY) readyTransactions++;
+            else if (tx.status === TransactionStatus.EXECUTED) executedTransactions++;
+            else if (tx.status === TransactionStatus.CANCELLED) cancelledTransactions++;
+            else if (tx.status === TransactionStatus.EXPIRED) expiredTransactions++;
+        });
+
+        const signerAnalytics = Array.from(this.signerStats.entries())
+            .map(([signer, stats]) => this.statsToAnalytics(signer, stats))
+            .sort((a, b) => a.signer.localeCompare(b.signer));
+
+        return {
+            totalTransactions: this.transactions.size,
+            readyTransactions,
+            executedTransactions,
+            cancelledTransactions,
+            expiredTransactions,
+            totalSignatures: this.totalSignatures,
+            totalRevocations: this.totalRevocations,
+            averageConfirmationDelayMs: this.totalSignatures > 0
+                ? this.totalConfirmationDelayMs / this.totalSignatures
+                : 0,
+            totalBatchGasSavings: this.totalBatchGasSavings,
+            signerAnalytics
+        };
+    }
+
+    public getSignerAnalytics(signer: string): SignerAnalytics {
+        const stats = this.signerStats.get(signer);
+        if (!stats) {
+            return {
+                signer,
+                signedCount: 0,
+                revokedCount: 0,
+                averageDelayMs: 0,
+                lastSignedAt: 0
+            };
+        }
+        return this.statsToAnalytics(signer, stats);
+    }
+
+    public getRequiredSignaturesForAmount(amount: number): number {
+        return this.getRuleForAmount(amount).requiredSignatures;
+    }
+
+    private createTransaction(
+        to: string,
+        value: number,
+        data: string,
+        sender: string,
+        workflowId?: string,
+        batchId?: string
+    ): string {
+        this.onlyOwner(sender);
+
+        if (!to) {
+            throw new Error('AdvancedMultiSig: target is required');
+        }
+        if (value < 0) {
+            throw new Error('AdvancedMultiSig: value must be non-negative');
+        }
+
+        const rule = this.getRuleForAmount(value);
+        const workflow = this.resolveWorkflowForRule(rule, workflowId);
+        const now = Date.now();
+
+        const stageApprovals: Record<string, string[]> = {};
+        const stageReadyAt: Record<string, number> = {};
+        const stageCompletedAt: Record<string, number> = {};
+        const isSequential = workflow.mode === WorkflowMode.SEQUENTIAL;
+        workflow.stages.forEach((stage) => {
+            stageApprovals[stage.id] = [];
+            stageReadyAt[stage.id] = isSequential
+                ? (stage.id === workflow.stages[0].id ? now : 0)
+                : now;
+            stageCompletedAt[stage.id] = 0;
+        });
+
+        const maxStageTimelock = workflow.stages.reduce(
+            (max, stage) => Math.max(max, stage.timelockMs),
+            0
+        );
+        const executionDelay = Math.max(
+            this.config.signatureTimelockMs,
+            rule.minExecutionDelayMs,
+            maxStageTimelock
+        );
+
+        const txId = MultiSigLib.hash(to, value, data, this.transactionNonce++);
+
+        const tx: AdvancedTransaction = {
+            id: txId,
+            to,
+            value,
+            data,
+            submittedBy: sender,
+            createdAt: now,
+            executeAfter: now + executionDelay,
+            expiresAt: now + this.config.transactionExpiryMs,
+            status: TransactionStatus.PENDING,
+            workflowId: workflow.id,
+            workflowMode: workflow.mode,
+            requiredSignatures: rule.requiredSignatures,
+            eligibleSigners: [...rule.eligibleSigners],
+            stages: workflow.stages.map((stage) => ({
+                ...stage,
+                approvers: [...stage.approvers]
+            })),
+            stageApprovals,
+            stageReadyAt,
+            stageCompletedAt,
+            currentStageIndex: 0,
+            confirmationCount: 0,
+            batchId,
+            lastUpdatedAt: now
+        };
+
+        this.transactions.set(txId, tx);
+        this.signatureLedger.set(txId, []);
+
+        return txId;
+    }
+
+    private resolveWorkflowForRule(
+        rule: HierarchicalThresholdRule,
+        workflowId?: string
+    ): WorkflowDefinition {
+        if (!workflowId) {
+            return {
+                id: `wf_default_${rule.id}`,
+                name: 'Default tier workflow',
+                mode: this.config.defaultWorkflowMode,
+                stages: [
+                    {
+                        id: 'tier_stage',
+                        name: 'Tier Approval',
+                        approvers: [...rule.eligibleSigners],
+                        minApprovals: rule.requiredSignatures,
+                        timelockMs: this.config.signatureTimelockMs
+                    }
+                ]
+            };
+        }
+
+        const existing = this.workflows.get(workflowId);
+        if (!existing) {
+            throw new Error('AdvancedMultiSig: workflow not found');
+        }
+
+        const workflow = this.cloneWorkflowDefinition(existing);
+        workflow.stages.forEach((stage) => {
+            if (stage.approvers.some((approver) => !rule.eligibleSigners.includes(approver))) {
+                throw new Error('AdvancedMultiSig: workflow approvers must be eligible under selected tier');
+            }
+        });
+
+        const uniqueApprovers = new Set(workflow.stages.flatMap((stage) => stage.approvers));
+        if (uniqueApprovers.size < rule.requiredSignatures) {
+            throw new Error('AdvancedMultiSig: workflow does not provide enough unique approvers for tier');
+        }
+
+        return workflow;
+    }
+
+    private resolveApprovalStage(tx: AdvancedTransaction, sender: string, stageId?: string): WorkflowStage {
+        if (tx.workflowMode === WorkflowMode.SEQUENTIAL) {
+            const nextStageIndex = this.getSequentialProgress(tx);
+            if (nextStageIndex >= tx.stages.length) {
+                throw new Error('AdvancedMultiSig: workflow already fully approved');
+            }
+
+            const stage = tx.stages[nextStageIndex];
+            if ((tx.stageReadyAt[stage.id] || 0) === 0) {
+                throw new Error('AdvancedMultiSig: next sequential stage is not active');
+            }
+            if (stageId && stage.id !== stageId) {
+                throw new Error('AdvancedMultiSig: invalid stage for sequential workflow');
+            }
+            if (!stage.approvers.includes(sender)) {
+                throw new Error('AdvancedMultiSig: signer not allowed in current sequential stage');
+            }
+            return stage;
+        }
+
+        if (stageId) {
+            const explicitStage = tx.stages.find((stage) => stage.id === stageId);
+            if (!explicitStage) {
+                throw new Error('AdvancedMultiSig: stage not found');
+            }
+            if (!explicitStage.approvers.includes(sender)) {
+                throw new Error('AdvancedMultiSig: signer not allowed in selected stage');
+            }
+            return explicitStage;
+        }
+
+        const inferredStage = tx.stages.find((stage) => {
+            const approvals = tx.stageApprovals[stage.id] || [];
+            return stage.approvers.includes(sender) && !approvals.includes(sender);
+        });
+
+        if (!inferredStage) {
+            throw new Error('AdvancedMultiSig: no available stage for signer confirmation');
+        }
+
+        return inferredStage;
+    }
+
+    private resolveRevocationStage(tx: AdvancedTransaction, sender: string, stageId?: string): WorkflowStage {
+        if (stageId) {
+            const stage = tx.stages.find((candidate) => candidate.id === stageId);
+            if (!stage) {
+                throw new Error('AdvancedMultiSig: stage not found');
+            }
+            if (!(tx.stageApprovals[stage.id] || []).includes(sender)) {
+                throw new Error('AdvancedMultiSig: signer has no active signature in selected stage');
+            }
+            return stage;
+        }
+
+        const stage = tx.stages.find((candidate) => (tx.stageApprovals[candidate.id] || []).includes(sender));
+        if (!stage) {
+            throw new Error('AdvancedMultiSig: signer has no active signature to revoke');
+        }
+
+        return stage;
+    }
+
+    private updateDerivedTransactionState(tx: AdvancedTransaction, now: number): void {
+        if (tx.status === TransactionStatus.EXECUTED || tx.status === TransactionStatus.CANCELLED) {
+            return;
+        }
+
+        if (now > tx.expiresAt) {
+            tx.status = TransactionStatus.EXPIRED;
+            tx.lastUpdatedAt = now;
+            return;
+        }
+
+        tx.currentStageIndex = this.getSequentialProgress(tx);
+        tx.confirmationCount = this.getUniqueApproverCount(tx);
+
+        const workflowSatisfied = this.isWorkflowSatisfied(tx);
+        const thresholdSatisfied = tx.confirmationCount >= tx.requiredSignatures;
+
+        tx.status = workflowSatisfied && thresholdSatisfied
+            ? TransactionStatus.READY
+            : TransactionStatus.PENDING;
+
+        tx.lastUpdatedAt = now;
+    }
+
+    private getSequentialProgress(tx: AdvancedTransaction): number {
+        if (tx.workflowMode !== WorkflowMode.SEQUENTIAL) {
+            return 0;
+        }
+
+        let currentIndex = 0;
+        while (currentIndex < tx.stages.length) {
+            const stage = tx.stages[currentIndex];
+            if (tx.stageCompletedAt[stage.id] > 0) {
+                currentIndex++;
+                continue;
+            }
+            break;
+        }
+        return currentIndex;
+    }
+
+    private isWorkflowSatisfied(tx: AdvancedTransaction): boolean {
+        if (tx.workflowMode === WorkflowMode.SEQUENTIAL) {
+            return this.getSequentialProgress(tx) === tx.stages.length;
+        }
+
+        return tx.stages.every((stage) => (tx.stageApprovals[stage.id] || []).length >= stage.minApprovals);
+    }
+
+    private getUniqueApproverCount(tx: AdvancedTransaction): number {
+        const uniqueApprovers = new Set<string>();
+        tx.stages.forEach((stage) => {
+            (tx.stageApprovals[stage.id] || []).forEach((approver) => uniqueApprovers.add(approver));
+        });
+        return uniqueApprovers.size;
+    }
+
+    private recordSignature(tx: AdvancedTransaction, signer: string, stageId: string, signedAt: number): void {
+        const ledger = this.signatureLedger.get(tx.id) || [];
+        ledger.push({
+            signer,
+            transactionId: tx.id,
+            stageId,
+            signedAt,
+            status: SignatureStatus.ACTIVE
+        });
+        this.signatureLedger.set(tx.id, ledger);
+
+        const stats = this.getOrCreateSignerStats(signer);
+        const delay = signedAt - tx.createdAt;
+        stats.signedCount += 1;
+        stats.totalDelayMs += delay;
+        stats.lastSignedAt = signedAt;
+
+        this.totalSignatures += 1;
+        this.totalConfirmationDelayMs += delay;
+    }
+
+    private recordRevocation(tx: AdvancedTransaction, signer: string, stageId: string, revokedAt: number): void {
+        const ledger = this.signatureLedger.get(tx.id) || [];
+        ledger.push({
+            signer,
+            transactionId: tx.id,
+            stageId,
+            signedAt: revokedAt,
+            status: SignatureStatus.REVOKED,
+            revokedAt
+        });
+        this.signatureLedger.set(tx.id, ledger);
+
+        const stats = this.getOrCreateSignerStats(signer);
+        stats.revokedCount += 1;
+        stats.lastRevokedAt = revokedAt;
+
+        this.totalRevocations += 1;
+    }
+
+    private statsToAnalytics(signer: string, stats: InternalSignerStats): SignerAnalytics {
+        return {
+            signer,
+            signedCount: stats.signedCount,
+            revokedCount: stats.revokedCount,
+            averageDelayMs: stats.signedCount > 0 ? stats.totalDelayMs / stats.signedCount : 0,
+            lastSignedAt: stats.lastSignedAt,
+            lastRevokedAt: stats.lastRevokedAt
+        };
+    }
+
+    private getOrCreateSignerStats(signer: string): InternalSignerStats {
+        const existing = this.signerStats.get(signer);
+        if (existing) {
+            return existing;
+        }
+        throw new Error('AdvancedMultiSig: signer stats unavailable');
+    }
+
+    private requireTransaction(transactionId: string): AdvancedTransaction {
+        const tx = this.transactions.get(transactionId);
+        if (!tx) {
+            throw new Error('AdvancedMultiSig: transaction not found');
+        }
+        return tx;
+    }
+
+    private requireActiveTransaction(transactionId: string): AdvancedTransaction {
+        const tx = this.requireTransaction(transactionId);
+
+        if (tx.status === TransactionStatus.EXECUTED) {
+            throw new Error('AdvancedMultiSig: transaction already executed');
+        }
+        if (tx.status === TransactionStatus.CANCELLED) {
+            throw new Error('AdvancedMultiSig: transaction already cancelled');
+        }
+
+        this.updateDerivedTransactionState(tx, Date.now());
+        if (tx.status === TransactionStatus.EXPIRED) {
+            this.transactions.set(tx.id, tx);
+            throw new Error('AdvancedMultiSig: transaction expired');
+        }
+
+        return tx;
+    }
+
+    private onlyOwner(sender: string): void {
+        if (!this.owners.has(sender)) {
+            throw new Error('AdvancedMultiSig: caller is not an owner');
+        }
+    }
+
+    private getRuleForAmount(amount: number): HierarchicalThresholdRule {
+        const rule = this.hierarchicalRules.find(
+            (candidate) => amount >= candidate.minAmount && amount <= candidate.maxAmount
+        );
+        if (!rule) {
+            throw new Error('AdvancedMultiSig: no hierarchical rule configured for amount');
+        }
+        return rule;
+    }
+
+    private validateWorkflowDefinition(workflow: WorkflowDefinition): void {
+        if (!workflow.id) {
+            throw new Error('AdvancedMultiSig: workflow id is required');
+        }
+        if (workflow.stages.length === 0) {
+            throw new Error('AdvancedMultiSig: workflow requires at least one stage');
+        }
+
+        const stageIds = new Set<string>();
+        workflow.stages.forEach((stage) => {
+            if (stageIds.has(stage.id)) {
+                throw new Error('AdvancedMultiSig: duplicate workflow stage id');
+            }
+            stageIds.add(stage.id);
+
+            if (stage.minApprovals < 1 || stage.minApprovals > stage.approvers.length) {
+                throw new Error('AdvancedMultiSig: invalid stage approval threshold');
+            }
+            if (stage.timelockMs < 0) {
+                throw new Error('AdvancedMultiSig: stage timelock cannot be negative');
+            }
+            stage.approvers.forEach((approver) => {
+                if (!this.owners.has(approver)) {
+                    throw new Error('AdvancedMultiSig: workflow approver must be an owner');
+                }
+            });
+        });
+    }
+
+    private setInternalHierarchicalRules(rules: HierarchicalThresholdRule[]): void {
+        if (rules.length === 0) {
+            throw new Error('AdvancedMultiSig: at least one hierarchical rule is required');
+        }
+
+        const normalized = rules
+            .map((rule) => ({
+                ...rule,
+                eligibleSigners: Array.from(new Set(rule.eligibleSigners))
+            }))
+            .sort((a, b) => a.minAmount - b.minAmount);
+
+        normalized.forEach((rule, index) => {
+            this.validateHierarchicalRule(rule);
+            if (index > 0) {
+                const previous = normalized[index - 1];
+                if (rule.minAmount <= previous.maxAmount) {
+                    throw new Error('AdvancedMultiSig: hierarchical rules overlap');
+                }
+            }
+        });
+
+        this.hierarchicalRules = normalized;
+    }
+
+    private validateHierarchicalRule(rule: HierarchicalThresholdRule): void {
+        if (!rule.id) {
+            throw new Error('AdvancedMultiSig: hierarchical rule id is required');
+        }
+        if (rule.minAmount < 0 || rule.maxAmount < 0 || rule.minAmount > rule.maxAmount) {
+            throw new Error('AdvancedMultiSig: invalid hierarchical amount range');
+        }
+        if (rule.requiredSignatures < 1) {
+            throw new Error('AdvancedMultiSig: hierarchical rule must require at least one signature');
+        }
+        if (rule.minExecutionDelayMs < 0) {
+            throw new Error('AdvancedMultiSig: hierarchical delay cannot be negative');
+        }
+        if (rule.eligibleSigners.length < rule.requiredSignatures) {
+            throw new Error('AdvancedMultiSig: insufficient eligible signers for required signatures');
+        }
+
+        rule.eligibleSigners.forEach((signer) => {
+            if (!this.owners.has(signer)) {
+                throw new Error('AdvancedMultiSig: eligible signer must be an owner');
+            }
+        });
+    }
+
+    private cloneTransaction(tx: AdvancedTransaction): AdvancedTransaction {
+        const stageApprovals = Object.entries(tx.stageApprovals).reduce<Record<string, string[]>>(
+            (acc, [stageId, approvals]) => {
+                acc[stageId] = [...approvals];
+                return acc;
+            },
+            {}
+        );
+        const stageReadyAt = Object.entries(tx.stageReadyAt).reduce<Record<string, number>>(
+            (acc, [stageId, readyAt]) => {
+                acc[stageId] = readyAt;
+                return acc;
+            },
+            {}
+        );
+        const stageCompletedAt = Object.entries(tx.stageCompletedAt).reduce<Record<string, number>>(
+            (acc, [stageId, completedAt]) => {
+                acc[stageId] = completedAt;
+                return acc;
+            },
+            {}
+        );
+
+        return {
+            ...tx,
+            eligibleSigners: [...tx.eligibleSigners],
+            stages: tx.stages.map((stage) => ({
+                ...stage,
+                approvers: [...stage.approvers]
+            })),
+            stageApprovals,
+            stageReadyAt,
+            stageCompletedAt
+        };
+    }
+
+    private resetDownstreamStages(tx: AdvancedTransaction, fromIndex: number): void {
+        for (let i = fromIndex; i < tx.stages.length; i++) {
+            const stage = tx.stages[i];
+            tx.stageApprovals[stage.id] = [];
+            tx.stageCompletedAt[stage.id] = 0;
+            tx.stageReadyAt[stage.id] = 0;
+        }
+    }
+
+    private cloneWorkflowDefinition(workflow: WorkflowDefinition): WorkflowDefinition {
+        return {
+            ...workflow,
+            stages: workflow.stages.map((stage) => ({
+                ...stage,
+                approvers: [...stage.approvers]
+            }))
+        };
+    }
+
+    private buildDefaultRules(): HierarchicalThresholdRule[] {
+        const ownerList = Array.from(this.owners);
+        const lowTierSigners = ownerList.slice(0, Math.min(3, ownerList.length));
+        const highTierSigners = ownerList.slice(0, Math.min(5, ownerList.length));
+
+        const lowTierRequired = Math.max(1, Math.min(2, lowTierSigners.length));
+        const highTierRequired = Math.max(lowTierRequired, Math.min(3, highTierSigners.length));
+
+        return [
+            {
+                id: 'tier_low',
+                minAmount: 0,
+                maxAmount: 10000,
+                requiredSignatures: lowTierRequired,
+                eligibleSigners: lowTierSigners,
+                minExecutionDelayMs: this.config.signatureTimelockMs
+            },
+            {
+                id: 'tier_high',
+                minAmount: 10001,
+                maxAmount: Number.MAX_SAFE_INTEGER,
+                requiredSignatures: highTierRequired,
+                eligibleSigners: highTierSigners,
+                minExecutionDelayMs: this.config.signatureTimelockMs
+            }
+        ];
+    }
+}

--- a/contracts/multisig/interfaces/IAdvancedMultiSig.ts
+++ b/contracts/multisig/interfaces/IAdvancedMultiSig.ts
@@ -1,0 +1,45 @@
+import {
+    AdvancedTransaction,
+    BatchPlan,
+    EmergencyActionType,
+    EmergencyOverrideRequest,
+    HierarchicalThresholdRule,
+    WorkflowDefinition
+} from '../structures/WorkflowStructure';
+import { MultiSigAnalytics, SignerAnalytics } from '../structures/SignatureStructure';
+
+export interface IAdvancedMultiSig {
+    submitTransaction(to: string, value: number, data: string, sender: string, workflowId?: string): string;
+    submitBatch(
+        transactions: Array<{ to: string; value: number; data: string }>,
+        sender: string,
+        workflowId?: string
+    ): string;
+    confirmTransaction(transactionId: string, sender: string, stageId?: string): void;
+    revokeSignature(transactionId: string, sender: string, stageId?: string): void;
+    executeTransaction(transactionId: string, sender: string): void;
+    executeBatch(batchId: string, sender: string): string[];
+
+    registerWorkflow(workflow: WorkflowDefinition, sender: string): void;
+    setHierarchicalRules(rules: HierarchicalThresholdRule[], sender: string): void;
+
+    registerIntegration(contractId: string, handler: (tx: AdvancedTransaction) => void, sender: string): void;
+    getRegisteredIntegrations(): string[];
+
+    requestEmergencyOverride(
+        transactionId: string,
+        action: EmergencyActionType,
+        reason: string,
+        sender: string
+    ): string;
+    approveEmergencyOverride(requestId: string, sender: string): void;
+    executeEmergencyOverride(requestId: string, sender: string): void;
+    getEmergencyOverrideRequest(requestId: string): EmergencyOverrideRequest;
+
+    getTransaction(transactionId: string): AdvancedTransaction;
+    getBatchPlan(batchId: string): BatchPlan;
+    getOwners(): string[];
+    getSystemAnalytics(): MultiSigAnalytics;
+    getSignerAnalytics(signer: string): SignerAnalytics;
+    getRequiredSignaturesForAmount(amount: number): number;
+}

--- a/contracts/multisig/libraries/MultiSigLib.ts
+++ b/contracts/multisig/libraries/MultiSigLib.ts
@@ -22,4 +22,64 @@ export class MultiSigLib {
     public static isValid(transaction: Transaction, currentTime: number): boolean {
         return currentTime <= transaction.deadline && !transaction.executed;
     }
+
+    /**
+     * Estimates the gas cost of a single signature operation.
+     */
+    public static estimateSignatureGas(signatureCount: number): number {
+        const baseSignatureGas = 18000;
+        return Math.max(baseSignatureGas, signatureCount * baseSignatureGas);
+    }
+
+    /**
+     * Estimates gas for a multisig transaction with workflow and signature complexity.
+     */
+    public static estimateTransactionGas(data: string, workflowStages: number, signatureCount: number): number {
+        const baseGas = 45000;
+        const dataGas = data.length * 12;
+        const workflowGas = workflowStages * 10000;
+        const signatureGas = this.estimateSignatureGas(signatureCount);
+        return baseGas + dataGas + workflowGas + signatureGas;
+    }
+
+    /**
+     * Calculates optimized gas usage for a transaction batch.
+     */
+    public static optimizeBatchGas(estimatedGasPerTx: number[]): {
+        originalGas: number;
+        optimizedGas: number;
+        gasSavings: number;
+        gasSavingsPct: number;
+    } {
+        const originalGas = estimatedGasPerTx.reduce((sum, gas) => sum + gas, 0);
+        if (estimatedGasPerTx.length === 0) {
+            return {
+                originalGas: 0,
+                optimizedGas: 0,
+                gasSavings: 0,
+                gasSavingsPct: 0
+            };
+        }
+
+        // Simulate storage/read amortization for batched execution.
+        const batchingDiscountPct = Math.min(25, 10 + estimatedGasPerTx.length * 2);
+        const optimizedGas = Math.floor(originalGas * (1 - batchingDiscountPct / 100));
+        const gasSavings = originalGas - optimizedGas;
+
+        return {
+            originalGas,
+            optimizedGas,
+            gasSavings,
+            gasSavingsPct: originalGas > 0 ? (gasSavings / originalGas) * 100 : 0
+        };
+    }
+
+    /**
+     * Returns the number of approvals required for a super-majority.
+     */
+    public static calculateSuperMajority(totalOwners: number, superMajorityPct: number): number {
+        if (totalOwners < 1) return 0;
+        const clampedPct = Math.max(1, Math.min(100, superMajorityPct));
+        return Math.ceil(totalOwners * (clampedPct / 100));
+    }
 }

--- a/contracts/multisig/structures/SignatureStructure.ts
+++ b/contracts/multisig/structures/SignatureStructure.ts
@@ -1,0 +1,35 @@
+export enum SignatureStatus {
+    ACTIVE = 'active',
+    REVOKED = 'revoked'
+}
+
+export interface SignatureRecord {
+    signer: string;
+    transactionId: string;
+    stageId: string;
+    signedAt: number;
+    status: SignatureStatus;
+    revokedAt?: number;
+}
+
+export interface SignerAnalytics {
+    signer: string;
+    signedCount: number;
+    revokedCount: number;
+    averageDelayMs: number;
+    lastSignedAt: number;
+    lastRevokedAt?: number;
+}
+
+export interface MultiSigAnalytics {
+    totalTransactions: number;
+    readyTransactions: number;
+    executedTransactions: number;
+    cancelledTransactions: number;
+    expiredTransactions: number;
+    totalSignatures: number;
+    totalRevocations: number;
+    averageConfirmationDelayMs: number;
+    totalBatchGasSavings: number;
+    signerAnalytics: SignerAnalytics[];
+}

--- a/contracts/multisig/structures/WorkflowStructure.ts
+++ b/contracts/multisig/structures/WorkflowStructure.ts
@@ -1,0 +1,97 @@
+export enum WorkflowMode {
+    SEQUENTIAL = 'sequential',
+    PARALLEL = 'parallel'
+}
+
+export enum TransactionStatus {
+    PENDING = 'pending',
+    READY = 'ready',
+    EXECUTED = 'executed',
+    CANCELLED = 'cancelled',
+    EXPIRED = 'expired'
+}
+
+export interface WorkflowStage {
+    id: string;
+    name: string;
+    approvers: string[];
+    minApprovals: number;
+    timelockMs: number;
+}
+
+export interface WorkflowDefinition {
+    id: string;
+    name: string;
+    mode: WorkflowMode;
+    stages: WorkflowStage[];
+}
+
+export interface HierarchicalThresholdRule {
+    id: string;
+    minAmount: number;
+    maxAmount: number;
+    requiredSignatures: number;
+    eligibleSigners: string[];
+    minExecutionDelayMs: number;
+}
+
+export interface AdvancedTransaction {
+    id: string;
+    to: string;
+    value: number;
+    data: string;
+    submittedBy: string;
+    createdAt: number;
+    executeAfter: number;
+    expiresAt: number;
+    status: TransactionStatus;
+    workflowId: string;
+    workflowMode: WorkflowMode;
+    requiredSignatures: number;
+    eligibleSigners: string[];
+    stages: WorkflowStage[];
+    stageApprovals: Record<string, string[]>;
+    stageReadyAt: Record<string, number>;
+    stageCompletedAt: Record<string, number>;
+    currentStageIndex: number;
+    confirmationCount: number;
+    batchId?: string;
+    lastUpdatedAt: number;
+    executedAt?: number;
+    cancelledReason?: string;
+}
+
+export interface BatchPlan {
+    id: string;
+    submittedBy: string;
+    transactionIds: string[];
+    createdAt: number;
+    estimatedStandaloneGas: number;
+    estimatedBatchGas: number;
+    gasSavings: number;
+    gasSavingsPct: number;
+    executed: boolean;
+}
+
+export enum EmergencyActionType {
+    EXECUTE_TRANSACTION = 'execute_transaction',
+    CANCEL_TRANSACTION = 'cancel_transaction'
+}
+
+export interface EmergencyOverrideRequest {
+    id: string;
+    transactionId: string;
+    action: EmergencyActionType;
+    reason: string;
+    requestedBy: string;
+    createdAt: number;
+    approvals: string[];
+    executed: boolean;
+}
+
+export interface AdvancedMultiSigConfig {
+    transactionExpiryMs: number;
+    signatureTimelockMs: number;
+    emergencySuperMajorityPct: number;
+    defaultWorkflowMode: WorkflowMode;
+}

--- a/docs/multisig/AdvancedMultiSig.md
+++ b/docs/multisig/AdvancedMultiSig.md
@@ -1,0 +1,72 @@
+# Advanced MultiSig
+
+`AdvancedMultiSig` extends the baseline DAO multisig with tiered signature rules, workflow-aware approvals, signature analytics, and emergency handling.
+
+## Features
+
+- Hierarchical signature requirements with amount-based tiers (for example `2-of-3` for small transactions and `3-of-5` for large transactions).
+- Time-based signature/execution locks through per-stage timelocks and rule-level execution delays.
+- Workflow-aware approvals:
+  - Sequential workflows (`stage_1` -> `stage_2`).
+  - Parallel workflows (multiple stages approved concurrently).
+- Signature revocation before execution.
+- Batch transaction submission and execution with estimated gas savings.
+- Emergency override requests requiring super-majority owner approvals.
+- Integration hooks for platform contracts (`Governance`, `FeeManager`, `TimelockController`, etc.).
+- Signature analytics with signer-level delay and revocation tracking.
+
+## Contract Layout
+
+- Contract: `contracts/multisig/AdvancedMultiSig.ts`
+- Interface: `contracts/multisig/interfaces/IAdvancedMultiSig.ts`
+- Structures:
+  - `contracts/multisig/structures/WorkflowStructure.ts`
+  - `contracts/multisig/structures/SignatureStructure.ts`
+- Library: `contracts/multisig/libraries/MultiSigLib.ts`
+
+## Core Flow
+
+1. Submit a transaction using `submitTransaction(...)` or many transactions with `submitBatch(...)`.
+2. Confirm approvals with `confirmTransaction(...)`, optionally by stage in workflow mode.
+3. Revoke with `revokeSignature(...)` before execution when needed.
+4. Execute with `executeTransaction(...)` or `executeBatch(...)` once threshold + workflow + timelock checks pass.
+5. If critical recovery is needed, use emergency override:
+   - `requestEmergencyOverride(...)`
+   - `approveEmergencyOverride(...)`
+   - `executeEmergencyOverride(...)` (requires super-majority)
+
+## Risk and Safety Controls
+
+- Tier-based signer eligibility prevents under-secured high-value approvals.
+- Workflow stage constraints enforce governance process order and segregation.
+- Timelocks prevent rushed approvals/executions.
+- Revocation support allows signers to withdraw approvals before execution.
+- Emergency actions require super-majority and are auditable through request records.
+
+## Analytics
+
+- `getSignerAnalytics(signer)` exposes:
+  - signed count
+  - revoked count
+  - average signature delay
+  - last activity timestamps
+- `getSystemAnalytics()` exposes aggregate counters:
+  - transaction state totals
+  - total signatures/revocations
+  - average confirmation delay
+  - cumulative batch gas savings
+
+## Deployment
+
+Use the deployment helper:
+
+```bash
+ts-node scripts/deploy_advanced_multisig.ts
+```
+
+This script seeds:
+
+- 5 owners
+- 2-tier signature policy
+- A sample sequential workflow
+- Default integration hooks for major platform contracts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4010 @@
+{
+  "name": "currentdao-contracts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "currentdao-contracts",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^20.17.30",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.5",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
+      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.3",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "currentdao-contracts",
+  "version": "1.0.0",
+  "private": true,
+  "description": "CurrentDAO contracts TypeScript simulation suite",
+  "scripts": {
+    "test": "jest",
+    "test:multisig": "jest tests/multisig --runInBand",
+    "test:advanced-multisig": "jest tests/multisig/AdvancedMultiSig.test.ts --runInBand",
+    "coverage:advanced-multisig": "jest tests/multisig/AdvancedMultiSig.test.ts tests/multisig/MultiSigLib.test.ts --runInBand --coverage --collectCoverageFrom='contracts/multisig/AdvancedMultiSig.ts' --collectCoverageFrom='contracts/multisig/libraries/MultiSigLib.ts' --coverageThreshold='{\"global\":{\"statements\":95,\"lines\":95,\"functions\":95}}'",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "deploy:advanced-multisig": "ts-node scripts/deploy_advanced_multisig.ts"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.17.30",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/scripts/deploy_advanced_multisig.ts
+++ b/scripts/deploy_advanced_multisig.ts
@@ -1,0 +1,110 @@
+import { AdvancedMultiSig } from '../contracts/multisig/AdvancedMultiSig';
+import { HierarchicalThresholdRule, WorkflowMode } from '../contracts/multisig/structures/WorkflowStructure';
+
+/**
+ * Script to deploy and initialize the advanced multisig workflow engine.
+ */
+async function deploy() {
+    console.log('Starting Advanced MultiSig deployment...');
+
+    const owners = [
+        '0xCouncilOwner1',
+        '0xCouncilOwner2',
+        '0xCouncilOwner3',
+        '0xCouncilOwner4',
+        '0xCouncilOwner5'
+    ];
+
+    const rules: HierarchicalThresholdRule[] = [
+        {
+            id: 'small_tx',
+            minAmount: 0,
+            maxAmount: 10000,
+            requiredSignatures: 2,
+            eligibleSigners: owners.slice(0, 3),
+            minExecutionDelayMs: 60_000
+        },
+        {
+            id: 'large_tx',
+            minAmount: 10001,
+            maxAmount: Number.MAX_SAFE_INTEGER,
+            requiredSignatures: 3,
+            eligibleSigners: owners,
+            minExecutionDelayMs: 60_000
+        }
+    ];
+
+    const advancedMultiSig = new AdvancedMultiSig(owners, rules, {
+        signatureTimelockMs: 60_000,
+        emergencySuperMajorityPct: 75,
+        defaultWorkflowMode: WorkflowMode.PARALLEL
+    });
+
+    advancedMultiSig.registerWorkflow(
+        {
+            id: 'enterprise_review',
+            name: 'Enterprise Review Workflow',
+            mode: WorkflowMode.SEQUENTIAL,
+            stages: [
+                {
+                    id: 'risk_committee',
+                    name: 'Risk Committee',
+                    approvers: owners.slice(0, 3),
+                    minApprovals: 2,
+                    timelockMs: 60_000
+                },
+                {
+                    id: 'treasury_committee',
+                    name: 'Treasury Committee',
+                    approvers: owners.slice(2, 5),
+                    minApprovals: 2,
+                    timelockMs: 60_000
+                }
+            ]
+        },
+        owners[0]
+    );
+
+    const platformContracts = [
+        'AccessControlList',
+        'Governance',
+        'QualityRating',
+        'EnergyEscrow',
+        'PriceOracle',
+        'TimelockController',
+        'EmergencyPause',
+        'FeeManager',
+        'DynamicFeeSwitch',
+        'BatchProcessor',
+        'UsageAnalytics',
+        'GovernanceAnalytics',
+        'MultiChainLiquidityPool',
+        'LocationRegistry',
+        'YieldFarming',
+        'SecurityMonitor',
+        'ReentrancyGuard',
+        'RegulatoryReporting',
+        'UpgradeManager',
+        'EmergencyMigration',
+        'ZeroKnowledgeProof',
+        'AssetWrapper',
+        'DAOMultiSig',
+        'GasOptimizer'
+    ];
+
+    platformContracts.forEach((contractId) => {
+        advancedMultiSig.registerIntegration(
+            contractId,
+            (tx) => console.log(`Integrated call routed to ${contractId} for transaction ${tx.id}`),
+            owners[0]
+        );
+    });
+
+    console.log('Advanced MultiSig deployed.');
+    console.log(`Owners: ${advancedMultiSig.getOwners().join(', ')}`);
+    console.log(`Integrations: ${advancedMultiSig.getRegisteredIntegrations().join(', ')}`);
+
+    return { advancedMultiSig };
+}
+
+deploy().catch(console.error);

--- a/tests/multisig/AdvancedMultiSig.test.ts
+++ b/tests/multisig/AdvancedMultiSig.test.ts
@@ -1,0 +1,1038 @@
+import { AdvancedMultiSig } from '../../contracts/multisig/AdvancedMultiSig';
+import {
+    EmergencyActionType,
+    HierarchicalThresholdRule,
+    TransactionStatus,
+    WorkflowMode
+} from '../../contracts/multisig/structures/WorkflowStructure';
+
+describe('AdvancedMultiSig', () => {
+    const owner1 = '0xOwner1';
+    const owner2 = '0xOwner2';
+    const owner3 = '0xOwner3';
+    const owner4 = '0xOwner4';
+    const owner5 = '0xOwner5';
+    const owners = [owner1, owner2, owner3, owner4, owner5];
+
+    const tierRules: HierarchicalThresholdRule[] = [
+        {
+            id: 'small',
+            minAmount: 0,
+            maxAmount: 10000,
+            requiredSignatures: 2,
+            eligibleSigners: [owner1, owner2, owner3],
+            minExecutionDelayMs: 1000
+        },
+        {
+            id: 'large',
+            minAmount: 10001,
+            maxAmount: Number.MAX_SAFE_INTEGER,
+            requiredSignatures: 3,
+            eligibleSigners: [owner1, owner2, owner3, owner4, owner5],
+            minExecutionDelayMs: 1000
+        }
+    ];
+
+    let multisig: AdvancedMultiSig;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+        multisig = new AdvancedMultiSig(owners, tierRules, {
+            signatureTimelockMs: 1000,
+            transactionExpiryMs: 7 * 24 * 60 * 60 * 1000,
+            emergencySuperMajorityPct: 75,
+            defaultWorkflowMode: WorkflowMode.PARALLEL
+        });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('supports hierarchical signatures for small and large transaction tiers', () => {
+        expect(multisig.getRequiredSignaturesForAmount(1000)).toBe(2);
+        expect(multisig.getRequiredSignaturesForAmount(500000)).toBe(3);
+    });
+
+    it('enforces time-based signature locks', () => {
+        const txId = multisig.submitTransaction('Governance', 1000, '0xabc', owner1);
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner1);
+        }).toThrow('AdvancedMultiSig: stage timelock active');
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner1);
+
+        expect(multisig.getTransaction(txId).confirmationCount).toBe(1);
+    });
+
+    it('supports sequential approval workflows', () => {
+        multisig.registerWorkflow(
+            {
+                id: 'wf_sequential',
+                name: 'Sequential Risk Review',
+                mode: WorkflowMode.SEQUENTIAL,
+                stages: [
+                    {
+                        id: 'risk',
+                        name: 'Risk Committee',
+                        approvers: [owner1, owner2],
+                        minApprovals: 2,
+                        timelockMs: 1000
+                    },
+                    {
+                        id: 'treasury',
+                        name: 'Treasury Committee',
+                        approvers: [owner3, owner4],
+                        minApprovals: 1,
+                        timelockMs: 1000
+                    }
+                ]
+            },
+            owner1
+        );
+
+        const txId = multisig.submitTransaction('FeeManager', 20000, '0x123', owner1, 'wf_sequential');
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner1, 'risk');
+        multisig.confirmTransaction(txId, owner2, 'risk');
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner3, 'treasury');
+        }).toThrow('AdvancedMultiSig: stage timelock active');
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner3, 'treasury');
+
+        const tx = multisig.getTransaction(txId);
+        expect(tx.currentStageIndex).toBe(2);
+        expect(tx.status).toBe(TransactionStatus.READY);
+    });
+
+    it('supports parallel approval workflows', () => {
+        multisig.registerWorkflow(
+            {
+                id: 'wf_parallel',
+                name: 'Parallel Review',
+                mode: WorkflowMode.PARALLEL,
+                stages: [
+                    {
+                        id: 'legal',
+                        name: 'Legal',
+                        approvers: [owner1, owner2, owner5],
+                        minApprovals: 1,
+                        timelockMs: 1000
+                    },
+                    {
+                        id: 'ops',
+                        name: 'Ops',
+                        approvers: [owner3, owner4],
+                        minApprovals: 1,
+                        timelockMs: 1000
+                    }
+                ]
+            },
+            owner1
+        );
+
+        const txId = multisig.submitTransaction('TimelockController', 20000, '0x234', owner1, 'wf_parallel');
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner1, 'legal');
+        multisig.confirmTransaction(txId, owner3, 'ops');
+        multisig.confirmTransaction(txId, owner5, 'legal');
+
+        expect(multisig.getTransaction(txId).status).toBe(TransactionStatus.READY);
+    });
+
+    it('allows signature revocation before execution', () => {
+        const txId = multisig.submitTransaction('Governance', 7000, '0xrev', owner1);
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner1);
+        multisig.confirmTransaction(txId, owner2);
+
+        expect(multisig.getTransaction(txId).status).toBe(TransactionStatus.READY);
+
+        multisig.revokeSignature(txId, owner2);
+        const tx = multisig.getTransaction(txId);
+
+        expect(tx.confirmationCount).toBe(1);
+        expect(tx.status).toBe(TransactionStatus.PENDING);
+    });
+
+    it('resets downstream approvals if an upstream sequential stage is revoked', () => {
+        multisig.registerWorkflow(
+            {
+                id: 'wf_revocation_reset',
+                name: 'Revocation Reset Workflow',
+                mode: WorkflowMode.SEQUENTIAL,
+                stages: [
+                    {
+                        id: 'stage_one',
+                        name: 'Stage One',
+                        approvers: [owner1, owner2],
+                        minApprovals: 2,
+                        timelockMs: 1000
+                    },
+                    {
+                        id: 'stage_two',
+                        name: 'Stage Two',
+                        approvers: [owner3, owner4],
+                        minApprovals: 1,
+                        timelockMs: 1000
+                    }
+                ]
+            },
+            owner1
+        );
+
+        const txId = multisig.submitTransaction('Governance', 20000, '0xrst', owner1, 'wf_revocation_reset');
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner1, 'stage_one');
+        multisig.confirmTransaction(txId, owner2, 'stage_one');
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner3, 'stage_two');
+        expect(multisig.getTransaction(txId).status).toBe(TransactionStatus.READY);
+
+        multisig.revokeSignature(txId, owner1, 'stage_one');
+
+        const tx = multisig.getTransaction(txId);
+        expect(tx.status).toBe(TransactionStatus.PENDING);
+        expect(tx.stageApprovals.stage_one).toEqual([owner2]);
+        expect(tx.stageApprovals.stage_two).toHaveLength(0);
+    });
+
+    it('optimizes gas for batched transactions and executes them together', () => {
+        const batchId = multisig.submitBatch(
+            [
+                { to: 'Governance', value: 1000, data: '0x1' },
+                { to: 'FeeManager', value: 2000, data: '0x2' },
+                { to: 'TimelockController', value: 3000, data: '0x3' }
+            ],
+            owner1
+        );
+
+        const batch = multisig.getBatchPlan(batchId);
+        expect(batch.estimatedBatchGas).toBeLessThan(batch.estimatedStandaloneGas);
+        expect(batch.gasSavings).toBeGreaterThan(0);
+
+        jest.advanceTimersByTime(1000);
+        batch.transactionIds.forEach((txId) => {
+            multisig.confirmTransaction(txId, owner1);
+            multisig.confirmTransaction(txId, owner2);
+        });
+
+        const executed = multisig.executeBatch(batchId, owner3);
+        expect(executed).toHaveLength(3);
+
+        executed.forEach((txId) => {
+            expect(multisig.getTransaction(txId).status).toBe(TransactionStatus.EXECUTED);
+        });
+    });
+
+    it('requires super-majority approvals for emergency override', () => {
+        const txId = multisig.submitTransaction('EmergencyPause', 500000, '0xemergency', owner1);
+
+        const overrideId = multisig.requestEmergencyOverride(
+            txId,
+            EmergencyActionType.EXECUTE_TRANSACTION,
+            'Critical security response',
+            owner1
+        );
+
+        multisig.approveEmergencyOverride(overrideId, owner2);
+        multisig.approveEmergencyOverride(overrideId, owner3);
+
+        expect(() => {
+            multisig.executeEmergencyOverride(overrideId, owner4);
+        }).toThrow('AdvancedMultiSig: emergency override requires super-majority approvals');
+
+        multisig.approveEmergencyOverride(overrideId, owner4);
+        multisig.executeEmergencyOverride(overrideId, owner5);
+
+        expect(multisig.getTransaction(txId).status).toBe(TransactionStatus.EXECUTED);
+    });
+
+    it('tracks signature analytics and approval delays', () => {
+        const txId = multisig.submitTransaction('Governance', 3000, '0xmetrics', owner1);
+
+        jest.advanceTimersByTime(2000);
+        multisig.confirmTransaction(txId, owner1);
+
+        jest.advanceTimersByTime(3000);
+        multisig.confirmTransaction(txId, owner2);
+
+        const signerOne = multisig.getSignerAnalytics(owner1);
+        const signerTwo = multisig.getSignerAnalytics(owner2);
+        const system = multisig.getSystemAnalytics();
+
+        expect(signerOne.averageDelayMs).toBe(2000);
+        expect(signerTwo.averageDelayMs).toBe(5000);
+        expect(system.totalSignatures).toBe(2);
+        expect(system.averageConfirmationDelayMs).toBe(3500);
+    });
+
+    it('executes integration hooks for all platform contracts', () => {
+        const platformContracts = [
+            'AccessControlList',
+            'Governance',
+            'QualityRating',
+            'EnergyEscrow',
+            'PriceOracle',
+            'TimelockController',
+            'EmergencyPause',
+            'FeeManager',
+            'DynamicFeeSwitch',
+            'BatchProcessor',
+            'UsageAnalytics',
+            'GovernanceAnalytics',
+            'MultiChainLiquidityPool',
+            'LocationRegistry',
+            'YieldFarming',
+            'SecurityMonitor',
+            'ReentrancyGuard',
+            'RegulatoryReporting',
+            'UpgradeManager',
+            'EmergencyMigration',
+            'ZeroKnowledgeProof',
+            'AssetWrapper',
+            'DAOMultiSig',
+            'GasOptimizer'
+        ];
+
+        const hooks = new Map<string, jest.Mock>();
+        platformContracts.forEach((contractId) => {
+            const hook = jest.fn();
+            hooks.set(contractId, hook);
+            multisig.registerIntegration(contractId, hook, owner1);
+        });
+
+        platformContracts.forEach((contractId) => {
+            const txId = multisig.submitTransaction(contractId, 4000, `0x${contractId}`, owner1);
+            jest.advanceTimersByTime(1000);
+            multisig.confirmTransaction(txId, owner1);
+            multisig.confirmTransaction(txId, owner2);
+            multisig.executeTransaction(txId, owner3);
+        });
+
+        platformContracts.forEach((contractId) => {
+            const hook = hooks.get(contractId)!;
+            expect(hook).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('enforces owner-only access on sensitive methods', () => {
+        expect(() => {
+            multisig.submitTransaction('Governance', 1000, '0x', '0xNonOwner');
+        }).toThrow('AdvancedMultiSig: caller is not an owner');
+
+        expect(() => {
+            multisig.registerWorkflow(
+                {
+                    id: 'wf_non_owner',
+                    name: 'Nope',
+                    mode: WorkflowMode.PARALLEL,
+                    stages: [
+                        {
+                            id: 's1',
+                            name: 'Stage',
+                            approvers: [owner1],
+                            minApprovals: 1,
+                            timelockMs: 0
+                        }
+                    ]
+                },
+                '0xNonOwner'
+            );
+        }).toThrow('AdvancedMultiSig: caller is not an owner');
+    });
+
+    it('validates constructor and default tier rules', () => {
+        expect(() => {
+            new AdvancedMultiSig([owner1]);
+        }).toThrow('AdvancedMultiSig: at least two owners required');
+
+        const defaultRulesMultisig = new AdvancedMultiSig([owner1, owner2, owner3], undefined, {
+            signatureTimelockMs: 1000
+        });
+
+        expect(defaultRulesMultisig.getRequiredSignaturesForAmount(100)).toBe(2);
+        expect(defaultRulesMultisig.getRequiredSignaturesForAmount(100000)).toBe(3);
+    });
+
+    it('validates transaction submission inputs', () => {
+        expect(() => {
+            multisig.submitTransaction('', 1000, '0x', owner1);
+        }).toThrow('AdvancedMultiSig: target is required');
+
+        expect(() => {
+            multisig.submitTransaction('Governance', -1, '0x', owner1);
+        }).toThrow('AdvancedMultiSig: value must be non-negative');
+
+        expect(() => {
+            multisig.submitBatch([], owner1);
+        }).toThrow('AdvancedMultiSig: empty batch not allowed');
+    });
+
+    it('validates hierarchical rule updates and detects gaps', () => {
+        expect(() => {
+            multisig.setHierarchicalRules([], owner1);
+        }).toThrow('AdvancedMultiSig: at least one hierarchical rule is required');
+
+        expect(() => {
+            multisig.setHierarchicalRules(
+                [
+                    {
+                        id: 'a',
+                        minAmount: 0,
+                        maxAmount: 100,
+                        requiredSignatures: 1,
+                        eligibleSigners: [owner1],
+                        minExecutionDelayMs: 0
+                    },
+                    {
+                        id: 'b',
+                        minAmount: 100,
+                        maxAmount: 200,
+                        requiredSignatures: 1,
+                        eligibleSigners: [owner1],
+                        minExecutionDelayMs: 0
+                    }
+                ],
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: hierarchical rules overlap');
+
+        expect(() => {
+            multisig.setHierarchicalRules(
+                [
+                    {
+                        id: '',
+                        minAmount: 0,
+                        maxAmount: 100,
+                        requiredSignatures: 1,
+                        eligibleSigners: [owner1],
+                        minExecutionDelayMs: 0
+                    }
+                ],
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: hierarchical rule id is required');
+
+        expect(() => {
+            multisig.setHierarchicalRules(
+                [
+                    {
+                        id: 'bad_range',
+                        minAmount: 10,
+                        maxAmount: 1,
+                        requiredSignatures: 1,
+                        eligibleSigners: [owner1],
+                        minExecutionDelayMs: 0
+                    }
+                ],
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: invalid hierarchical amount range');
+
+        expect(() => {
+            multisig.setHierarchicalRules(
+                [
+                    {
+                        id: 'bad_req',
+                        minAmount: 0,
+                        maxAmount: 100,
+                        requiredSignatures: 0,
+                        eligibleSigners: [owner1],
+                        minExecutionDelayMs: 0
+                    }
+                ],
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: hierarchical rule must require at least one signature');
+
+        expect(() => {
+            multisig.setHierarchicalRules(
+                [
+                    {
+                        id: 'bad_delay',
+                        minAmount: 0,
+                        maxAmount: 100,
+                        requiredSignatures: 1,
+                        eligibleSigners: [owner1],
+                        minExecutionDelayMs: -1
+                    }
+                ],
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: hierarchical delay cannot be negative');
+
+        expect(() => {
+            multisig.setHierarchicalRules(
+                [
+                    {
+                        id: 'bad_eligibility',
+                        minAmount: 0,
+                        maxAmount: 100,
+                        requiredSignatures: 2,
+                        eligibleSigners: [owner1],
+                        minExecutionDelayMs: 0
+                    }
+                ],
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: insufficient eligible signers for required signatures');
+
+        expect(() => {
+            multisig.setHierarchicalRules(
+                [
+                    {
+                        id: 'bad_owner',
+                        minAmount: 0,
+                        maxAmount: 100,
+                        requiredSignatures: 1,
+                        eligibleSigners: ['0xNotOwner'],
+                        minExecutionDelayMs: 0
+                    }
+                ],
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: eligible signer must be an owner');
+
+        multisig.setHierarchicalRules(
+            [
+                {
+                    id: 'low',
+                    minAmount: 0,
+                    maxAmount: 100,
+                    requiredSignatures: 1,
+                    eligibleSigners: [owner1],
+                    minExecutionDelayMs: 0
+                },
+                {
+                    id: 'high',
+                    minAmount: 200,
+                    maxAmount: 500,
+                    requiredSignatures: 1,
+                    eligibleSigners: [owner1],
+                    minExecutionDelayMs: 0
+                }
+            ],
+            owner1
+        );
+
+        expect(() => {
+            multisig.getRequiredSignaturesForAmount(150);
+        }).toThrow('AdvancedMultiSig: no hierarchical rule configured for amount');
+    });
+
+    it('validates workflow registration and workflow-to-tier compatibility', () => {
+        expect(() => {
+            multisig.registerWorkflow(
+                {
+                    id: '',
+                    name: 'x',
+                    mode: WorkflowMode.PARALLEL,
+                    stages: []
+                },
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: workflow id is required');
+
+        expect(() => {
+            multisig.registerWorkflow(
+                {
+                    id: 'wf_empty',
+                    name: 'x',
+                    mode: WorkflowMode.PARALLEL,
+                    stages: []
+                },
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: workflow requires at least one stage');
+
+        expect(() => {
+            multisig.registerWorkflow(
+                {
+                    id: 'wf_dup',
+                    name: 'x',
+                    mode: WorkflowMode.PARALLEL,
+                    stages: [
+                        { id: 's', name: 'a', approvers: [owner1], minApprovals: 1, timelockMs: 0 },
+                        { id: 's', name: 'b', approvers: [owner2], minApprovals: 1, timelockMs: 0 }
+                    ]
+                },
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: duplicate workflow stage id');
+
+        expect(() => {
+            multisig.registerWorkflow(
+                {
+                    id: 'wf_bad_threshold',
+                    name: 'x',
+                    mode: WorkflowMode.PARALLEL,
+                    stages: [
+                        { id: 's1', name: 'a', approvers: [owner1], minApprovals: 2, timelockMs: 0 }
+                    ]
+                },
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: invalid stage approval threshold');
+
+        expect(() => {
+            multisig.registerWorkflow(
+                {
+                    id: 'wf_bad_time',
+                    name: 'x',
+                    mode: WorkflowMode.PARALLEL,
+                    stages: [
+                        { id: 's1', name: 'a', approvers: [owner1], minApprovals: 1, timelockMs: -1 }
+                    ]
+                },
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: stage timelock cannot be negative');
+
+        expect(() => {
+            multisig.registerWorkflow(
+                {
+                    id: 'wf_bad_owner',
+                    name: 'x',
+                    mode: WorkflowMode.PARALLEL,
+                    stages: [
+                        { id: 's1', name: 'a', approvers: ['0xUnknown'], minApprovals: 1, timelockMs: 0 }
+                    ]
+                },
+                owner1
+            );
+        }).toThrow('AdvancedMultiSig: workflow approver must be an owner');
+
+        expect(() => {
+            multisig.submitTransaction('Governance', 1000, '0x', owner1, 'wf_missing');
+        }).toThrow('AdvancedMultiSig: workflow not found');
+
+        multisig.registerWorkflow(
+            {
+                id: 'wf_ineligible_approver',
+                name: 'x',
+                mode: WorkflowMode.PARALLEL,
+                stages: [
+                    { id: 's1', name: 'a', approvers: [owner4], minApprovals: 1, timelockMs: 0 }
+                ]
+            },
+            owner1
+        );
+
+        expect(() => {
+            multisig.submitTransaction('Governance', 1000, '0x', owner1, 'wf_ineligible_approver');
+        }).toThrow('AdvancedMultiSig: workflow approvers must be eligible under selected tier');
+
+        multisig.registerWorkflow(
+            {
+                id: 'wf_not_enough_unique',
+                name: 'x',
+                mode: WorkflowMode.PARALLEL,
+                stages: [
+                    { id: 's1', name: 'a', approvers: [owner1], minApprovals: 1, timelockMs: 0 }
+                ]
+            },
+            owner1
+        );
+
+        expect(() => {
+            multisig.submitTransaction('Governance', 20000, '0x', owner1, 'wf_not_enough_unique');
+        }).toThrow('AdvancedMultiSig: workflow does not provide enough unique approvers for tier');
+    });
+
+    it('covers confirmation, revocation and execution failure paths', () => {
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1);
+
+        expect(() => {
+            multisig.confirmTransaction('missing_tx', owner1);
+        }).toThrow('AdvancedMultiSig: transaction not found');
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner1);
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner1, 'tier_stage');
+        }).toThrow('AdvancedMultiSig: signer already confirmed this stage');
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner4);
+        }).toThrow('AdvancedMultiSig: signer not eligible for this tier');
+
+        expect(() => {
+            multisig.executeTransaction(txId, owner2);
+        }).toThrow('AdvancedMultiSig: transaction not ready for execution');
+
+        multisig.confirmTransaction(txId, owner2);
+        multisig.executeTransaction(txId, owner3);
+
+        expect(() => {
+            multisig.executeTransaction(txId, owner3);
+        }).toThrow('AdvancedMultiSig: transaction already executed');
+
+        expect(() => {
+            multisig.revokeSignature(txId, owner1);
+        }).toThrow('AdvancedMultiSig: transaction already executed');
+    });
+
+    it('covers stage-specific approval and revocation errors', () => {
+        multisig.registerWorkflow(
+            {
+                id: 'wf_stage_errors',
+                name: 'x',
+                mode: WorkflowMode.PARALLEL,
+                stages: [
+                    { id: 'alpha', name: 'a', approvers: [owner1], minApprovals: 1, timelockMs: 1000 },
+                    { id: 'beta', name: 'b', approvers: [owner2], minApprovals: 1, timelockMs: 1000 }
+                ]
+            },
+            owner1
+        );
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1, 'wf_stage_errors');
+        jest.advanceTimersByTime(1000);
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner1, 'missing');
+        }).toThrow('AdvancedMultiSig: stage not found');
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner2, 'alpha');
+        }).toThrow('AdvancedMultiSig: signer not allowed in selected stage');
+
+        multisig.confirmTransaction(txId, owner1, 'alpha');
+        multisig.confirmTransaction(txId, owner2, 'beta');
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner3);
+        }).toThrow('AdvancedMultiSig: no available stage for signer confirmation');
+
+        expect(() => {
+            multisig.revokeSignature(txId, owner3);
+        }).toThrow('AdvancedMultiSig: signer has no active signature to revoke');
+
+        expect(() => {
+            multisig.revokeSignature(txId, owner3, 'alpha');
+        }).toThrow('AdvancedMultiSig: signer has no active signature in selected stage');
+
+        expect(() => {
+            multisig.revokeSignature(txId, owner1, 'does_not_exist');
+        }).toThrow('AdvancedMultiSig: stage not found');
+    });
+
+    it('covers sequential-specific stage authorization failures', () => {
+        multisig.registerWorkflow(
+            {
+                id: 'wf_seq_errors',
+                name: 'x',
+                mode: WorkflowMode.SEQUENTIAL,
+                stages: [
+                    { id: 'one', name: '1', approvers: [owner1], minApprovals: 1, timelockMs: 1000 },
+                    { id: 'two', name: '2', approvers: [owner2], minApprovals: 1, timelockMs: 1000 }
+                ]
+            },
+            owner1
+        );
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1, 'wf_seq_errors');
+        jest.advanceTimersByTime(1000);
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner1, 'two');
+        }).toThrow('AdvancedMultiSig: invalid stage for sequential workflow');
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner2);
+        }).toThrow('AdvancedMultiSig: signer not allowed in current sequential stage');
+
+        multisig.confirmTransaction(txId, owner1, 'one');
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner2, 'two');
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner2, 'two');
+        }).toThrow('AdvancedMultiSig: workflow already fully approved');
+    });
+
+    it('covers batch execution error paths', () => {
+        expect(() => {
+            multisig.executeBatch('missing_batch', owner1);
+        }).toThrow('AdvancedMultiSig: batch not found');
+
+        const batchId = multisig.submitBatch(
+            [
+                { to: 'Governance', value: 1000, data: '0x1' },
+                { to: 'FeeManager', value: 1000, data: '0x2' }
+            ],
+            owner1
+        );
+        const batch = multisig.getBatchPlan(batchId);
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(batch.transactionIds[0], owner1);
+        multisig.confirmTransaction(batch.transactionIds[0], owner2);
+
+        expect(() => {
+            multisig.executeBatch(batchId, owner1);
+        }).toThrow('AdvancedMultiSig: batch contains non-executable transactions');
+
+        multisig.confirmTransaction(batch.transactionIds[1], owner1);
+        multisig.confirmTransaction(batch.transactionIds[1], owner2);
+        multisig.executeBatch(batchId, owner1);
+
+        expect(() => {
+            multisig.executeBatch(batchId, owner1);
+        }).toThrow('AdvancedMultiSig: batch already executed');
+    });
+
+    it('covers emergency override edge cases', () => {
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1);
+
+        expect(() => {
+            multisig.approveEmergencyOverride('missing_override', owner1);
+        }).toThrow('AdvancedMultiSig: emergency request not found');
+
+        expect(() => {
+            multisig.executeEmergencyOverride('missing_override', owner1);
+        }).toThrow('AdvancedMultiSig: emergency request not found');
+
+        const overrideId = multisig.requestEmergencyOverride(
+            txId,
+            EmergencyActionType.EXECUTE_TRANSACTION,
+            'test',
+            owner1
+        );
+
+        expect(() => {
+            multisig.approveEmergencyOverride(overrideId, owner1);
+        }).toThrow('AdvancedMultiSig: emergency approval already recorded');
+
+        multisig.approveEmergencyOverride(overrideId, owner2);
+        multisig.approveEmergencyOverride(overrideId, owner3);
+        multisig.approveEmergencyOverride(overrideId, owner4);
+        multisig.executeEmergencyOverride(overrideId, owner5);
+
+        expect(() => {
+            multisig.approveEmergencyOverride(overrideId, owner2);
+        }).toThrow('AdvancedMultiSig: emergency request already executed');
+
+        expect(() => {
+            multisig.executeEmergencyOverride(overrideId, owner2);
+        }).toThrow('AdvancedMultiSig: emergency request already executed');
+
+        expect(() => {
+            multisig.requestEmergencyOverride(txId, EmergencyActionType.CANCEL_TRANSACTION, 'late', owner1);
+        }).toThrow('AdvancedMultiSig: cannot override executed transaction');
+    });
+
+    it('covers emergency cancellation flow and executed-cancel protection', () => {
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1);
+        const cancelId = multisig.requestEmergencyOverride(
+            txId,
+            EmergencyActionType.CANCEL_TRANSACTION,
+            'risk block',
+            owner1
+        );
+        multisig.approveEmergencyOverride(cancelId, owner2);
+        multisig.approveEmergencyOverride(cancelId, owner3);
+        multisig.approveEmergencyOverride(cancelId, owner4);
+        multisig.executeEmergencyOverride(cancelId, owner5);
+
+        expect(multisig.getTransaction(txId).status).toBe(TransactionStatus.CANCELLED);
+        expect(() => {
+            multisig.confirmTransaction(txId, owner1);
+        }).toThrow('AdvancedMultiSig: transaction already cancelled');
+
+        const txId2 = multisig.submitTransaction('Governance', 1000, '0x2', owner1);
+        const cancelId2 = multisig.requestEmergencyOverride(
+            txId2,
+            EmergencyActionType.CANCEL_TRANSACTION,
+            'late cancel',
+            owner1
+        );
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId2, owner1);
+        multisig.confirmTransaction(txId2, owner2);
+        multisig.executeTransaction(txId2, owner3);
+        multisig.approveEmergencyOverride(cancelId2, owner2);
+        multisig.approveEmergencyOverride(cancelId2, owner3);
+        multisig.approveEmergencyOverride(cancelId2, owner4);
+
+        expect(() => {
+            multisig.executeEmergencyOverride(cancelId2, owner5);
+        }).toThrow('AdvancedMultiSig: cannot cancel executed transaction');
+    });
+
+    it('covers emergency execute override on already executed transaction', () => {
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1);
+        const execId = multisig.requestEmergencyOverride(
+            txId,
+            EmergencyActionType.EXECUTE_TRANSACTION,
+            'force',
+            owner1
+        );
+
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner1);
+        multisig.confirmTransaction(txId, owner2);
+        multisig.executeTransaction(txId, owner3);
+        multisig.approveEmergencyOverride(execId, owner2);
+        multisig.approveEmergencyOverride(execId, owner3);
+        multisig.approveEmergencyOverride(execId, owner4);
+
+        expect(() => {
+            multisig.executeEmergencyOverride(execId, owner5);
+        }).toThrow('AdvancedMultiSig: transaction already executed');
+    });
+
+    it('covers getters and not-found paths', () => {
+        expect(() => {
+            multisig.getTransaction('missing_tx');
+        }).toThrow('AdvancedMultiSig: transaction not found');
+
+        expect(() => {
+            multisig.getBatchPlan('missing_batch');
+        }).toThrow('AdvancedMultiSig: batch not found');
+
+        expect(() => {
+            multisig.getEmergencyOverrideRequest('missing_override');
+        }).toThrow('AdvancedMultiSig: emergency request not found');
+
+        const unknown = multisig.getSignerAnalytics('0xUnknown');
+        expect(unknown.signedCount).toBe(0);
+        expect(unknown.averageDelayMs).toBe(0);
+    });
+
+    it('covers expiry handling and analytics states', () => {
+        const shortLived = new AdvancedMultiSig(owners, tierRules, {
+            signatureTimelockMs: 0,
+            transactionExpiryMs: 10,
+            emergencySuperMajorityPct: 75,
+            defaultWorkflowMode: WorkflowMode.PARALLEL
+        });
+        const txId = shortLived.submitTransaction('Governance', 1000, '0x', owner1);
+        jest.advanceTimersByTime(20);
+
+        expect(() => {
+            shortLived.confirmTransaction(txId, owner1);
+        }).toThrow('AdvancedMultiSig: transaction expired');
+
+        const analytics = shortLived.getSystemAnalytics();
+        expect(analytics.expiredTransactions).toBe(1);
+    });
+
+    it('covers stage-activation guard and signer-stats guard via tamper scenarios', () => {
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1);
+        const internal = multisig as unknown as {
+            transactions: Map<string, any>;
+            signerStats: Map<string, any>;
+        };
+        const tx = internal.transactions.get(txId);
+        tx.stageReadyAt.tier_stage = 0;
+        internal.transactions.set(txId, tx);
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner1);
+        }).toThrow('AdvancedMultiSig: stage is not yet active');
+
+        tx.stageReadyAt.tier_stage = Date.now() - 1000;
+        internal.transactions.set(txId, tx);
+        internal.signerStats.delete(owner1);
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner1);
+        }).toThrow('AdvancedMultiSig: signer stats unavailable');
+    });
+
+    it('covers registration getters and explicit timelock execution guard', () => {
+        expect(() => {
+            multisig.registerIntegration('', () => undefined, owner1);
+        }).toThrow('AdvancedMultiSig: integration id is required');
+
+        multisig.registerIntegration('Governance', () => undefined, owner1);
+        expect(multisig.getRegisteredIntegrations()).toContain('Governance');
+
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1);
+        jest.advanceTimersByTime(1000);
+        multisig.confirmTransaction(txId, owner1);
+        multisig.confirmTransaction(txId, owner2);
+
+        const internal = multisig as unknown as { transactions: Map<string, any> };
+        const tx = internal.transactions.get(txId);
+        tx.executeAfter = Date.now() + 10_000;
+        internal.transactions.set(txId, tx);
+
+        expect(() => {
+            multisig.executeTransaction(txId, owner3);
+        }).toThrow('AdvancedMultiSig: execution timelock active');
+    });
+
+    it('covers emergency execute integration callback and request getter copy', () => {
+        const hook = jest.fn();
+        multisig.registerIntegration('EmergencyPause', hook, owner1);
+
+        const txId = multisig.submitTransaction('EmergencyPause', 1000, '0x', owner1);
+        const requestId = multisig.requestEmergencyOverride(
+            txId,
+            EmergencyActionType.EXECUTE_TRANSACTION,
+            'urgent',
+            owner1
+        );
+        multisig.approveEmergencyOverride(requestId, owner2);
+        multisig.approveEmergencyOverride(requestId, owner3);
+        multisig.approveEmergencyOverride(requestId, owner4);
+
+        const snapshot = multisig.getEmergencyOverrideRequest(requestId);
+        snapshot.approvals.push('0xMutate');
+
+        const fresh = multisig.getEmergencyOverrideRequest(requestId);
+        expect(fresh.approvals).not.toContain('0xMutate');
+
+        multisig.executeEmergencyOverride(requestId, owner5);
+        expect(hook).toHaveBeenCalledTimes(1);
+        expect(multisig.getOwners()).toContain(owner1);
+    });
+
+    it('covers sequential inactive-stage guard via tamper and executed/cancelled no-op state updates', () => {
+        multisig.registerWorkflow(
+            {
+                id: 'wf_seq_tamper',
+                name: 'x',
+                mode: WorkflowMode.SEQUENTIAL,
+                stages: [
+                    { id: 'a', name: 'a', approvers: [owner1], minApprovals: 1, timelockMs: 0 },
+                    { id: 'b', name: 'b', approvers: [owner2], minApprovals: 1, timelockMs: 0 }
+                ]
+            },
+            owner1
+        );
+        const txId = multisig.submitTransaction('Governance', 1000, '0x', owner1, 'wf_seq_tamper');
+        const internals = multisig as unknown as { transactions: Map<string, any>; updateDerivedTransactionState: (tx: any, now: number) => void };
+        const tx = internals.transactions.get(txId);
+        tx.stageCompletedAt.a = Date.now();
+        tx.stageReadyAt.b = 0;
+        internals.transactions.set(txId, tx);
+
+        expect(() => {
+            multisig.confirmTransaction(txId, owner2);
+        }).toThrow('AdvancedMultiSig: next sequential stage is not active');
+
+        tx.status = TransactionStatus.EXECUTED;
+        tx.lastUpdatedAt = 1;
+        internals.updateDerivedTransactionState(tx, Date.now());
+        expect(tx.lastUpdatedAt).toBe(1);
+
+        tx.status = TransactionStatus.CANCELLED;
+        tx.lastUpdatedAt = 2;
+        internals.updateDerivedTransactionState(tx, Date.now());
+        expect(tx.lastUpdatedAt).toBe(2);
+    });
+});

--- a/tests/multisig/MultiSigLib.test.ts
+++ b/tests/multisig/MultiSigLib.test.ts
@@ -1,0 +1,54 @@
+import { MultiSigLib } from '../../contracts/multisig/libraries/MultiSigLib';
+import { Transaction } from '../../contracts/multisig/structures/MultiSigStructure';
+
+describe('MultiSigLib', () => {
+    it('evaluates readiness and validity for legacy transaction structure', () => {
+        const tx: Transaction = {
+            id: 'tx',
+            to: '0xTarget',
+            value: 10,
+            data: '0xabc',
+            executed: false,
+            numConfirmations: 2,
+            timestamp: Date.now(),
+            deadline: Date.now() + 10_000
+        };
+
+        expect(MultiSigLib.isReady(tx, 2)).toBe(true);
+        expect(MultiSigLib.isReady(tx, 3)).toBe(false);
+        expect(MultiSigLib.isValid(tx, Date.now())).toBe(true);
+        expect(MultiSigLib.isValid(tx, tx.deadline + 1)).toBe(false);
+    });
+
+    it('hashes and estimates gas values', () => {
+        const hash = MultiSigLib.hash('0xabc123', 25, '0xdeadbeef', 7);
+        expect(hash.startsWith('MS_TX_')).toBe(true);
+
+        expect(MultiSigLib.estimateSignatureGas(0)).toBe(18000);
+        expect(MultiSigLib.estimateSignatureGas(2)).toBe(36000);
+
+        const txGas = MultiSigLib.estimateTransactionGas('0xdeadbeef', 2, 3);
+        expect(txGas).toBeGreaterThan(0);
+    });
+
+    it('optimizes batch gas and handles empty batches', () => {
+        const optimized = MultiSigLib.optimizeBatchGas([100_000, 120_000, 80_000]);
+        expect(optimized.originalGas).toBe(300_000);
+        expect(optimized.optimizedGas).toBeLessThan(300_000);
+        expect(optimized.gasSavings).toBeGreaterThan(0);
+        expect(optimized.gasSavingsPct).toBeGreaterThan(0);
+
+        const empty = MultiSigLib.optimizeBatchGas([]);
+        expect(empty.originalGas).toBe(0);
+        expect(empty.optimizedGas).toBe(0);
+        expect(empty.gasSavings).toBe(0);
+        expect(empty.gasSavingsPct).toBe(0);
+    });
+
+    it('calculates super-majority with edge cases', () => {
+        expect(MultiSigLib.calculateSuperMajority(0, 75)).toBe(0);
+        expect(MultiSigLib.calculateSuperMajority(5, 75)).toBe(4);
+        expect(MultiSigLib.calculateSuperMajority(5, 110)).toBe(5);
+        expect(MultiSigLib.calculateSuperMajority(5, -1)).toBe(1);
+    });
+});


### PR DESCRIPTION
# Advanced MultiSig Contract - Pull Request

## Summary
Implements an advanced multi-signature transaction system with hierarchical signature thresholds, time-based locks, complex approval workflows, signature revocation, batching, emergency override controls, analytics, and platform-wide integration hooks.

## Linked Issue
Closes #22
Closes https://github.com/CurrentDao-org/CurrentDao-contracts/issues/22

## What Was Implemented
- Advanced multisig contract with workflow/tier orchestration:
  - `contracts/multisig/AdvancedMultiSig.ts`
- New interface:
  - `contracts/multisig/interfaces/IAdvancedMultiSig.ts`
- New structures:
  - `contracts/multisig/structures/WorkflowStructure.ts`
  - `contracts/multisig/structures/SignatureStructure.ts`
- MultiSig library enhancements for gas and super-majority helpers:
  - `contracts/multisig/libraries/MultiSigLib.ts`
- Deployment script:
  - `scripts/deploy_advanced_multisig.ts`
- Documentation:
  - `docs/multisig/AdvancedMultiSig.md`
- Test suites:
  - `tests/multisig/AdvancedMultiSig.test.ts`
  - `tests/multisig/MultiSigLib.test.ts`

## Acceptance Criteria Mapping
- Hierarchical signatures (2-of-3 small, 3-of-5 large): ✅
- Time-locks prevent rushed approvals/execution: ✅
- Sequential and parallel workflows: ✅
- Signature revocation before execution: ✅
- Batching with gas-saving estimates: ✅
- Emergency override with super-majority: ✅
- Signature pattern/delay analytics: ✅
- Integration hooks for platform contracts: ✅
- Gas optimization helpers in multisig library: ✅

## Verification Performed
- Multisig tests:
  - `npm run test:multisig`
- Advanced coverage gate:
  - `npm run coverage:advanced-multisig`
  - Result: `99.55%` statements, `100%` lines, `100%` functions (global for advanced multisig scope)
- Security dependency check:
  - `npm audit --audit-level=high`
  - Result: `found 0 vulnerabilities`

## Notes
- Coverage artifacts under `coverage/` are generated outputs and were intentionally not included in the feature commit.
